### PR TITLE
ci(release): build Windows, macOS en Linux installers op tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,166 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # ── 1. Pre-flight check ───────────────────────────────────
+  # De frontend die daadwerkelijk wordt gebundeld staat in design-mockup/
+  # (zie build.frontendDist in src-tauri/tauri.conf.json). Faalt die build,
+  # dan heeft het geen zin om drie platformen te bouwen.
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: actions/cache@v5
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('design-mockup/package-lock.json') }}
+          restore-keys: npm-${{ runner.os }}-
+      - run: npm ci
+        working-directory: design-mockup
+      - run: npm run build
+        working-directory: design-mockup
+
+  # ── 2. Installers bouwen ──────────────────────────────────
+  build:
+    needs: check
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows-latest
+            rust-target: x86_64-pc-windows-msvc
+            label: Windows
+            bundles: msi,nsis
+          - platform: macos-latest
+            rust-target: universal-apple-darwin
+            label: macOS
+            bundles: app,dmg
+          - platform: ubuntu-22.04
+            rust-target: x86_64-unknown-linux-gnu
+            label: Linux
+            bundles: appimage,deb
+
+    name: Build – ${{ matrix.label }}
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Cache npm
+        uses: actions/cache@v5
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('design-mockup/package-lock.json') }}
+          restore-keys: npm-${{ runner.os }}-
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Rust targets (macOS universal)
+        if: runner.os == 'macOS'
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2.9.1
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libgtk-3-dev \
+            patchelf
+
+      # beforeBuildCommand in tauri.conf.json draait `cd design-mockup &&
+      # npm run build`; de dependencies daarvan moeten dus vooraf staan.
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: design-mockup
+
+      - name: Build Tauri app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: open-fem2d-studio-${{ matrix.label }}
+          path: |
+            src-tauri/target/${{ matrix.rust-target }}/release/bundle/nsis/*.exe
+            src-tauri/target/${{ matrix.rust-target }}/release/bundle/msi/*.msi
+            src-tauri/target/${{ matrix.rust-target }}/release/bundle/dmg/*.dmg
+            src-tauri/target/${{ matrix.rust-target }}/release/bundle/appimage/*.AppImage
+            src-tauri/target/${{ matrix.rust-target }}/release/bundle/deb/*.deb
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # ── 3. Concept-release publiceren ─────────────────────────
+  # Draft, zodat de release-notities eerst nagelopen kunnen worden.
+  publish:
+    name: Publish Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+
+      - name: Collect installer files
+        run: |
+          mkdir -p release
+          find artifacts -name '*-setup.exe' -exec cp {} release/ \;
+          find artifacts -name '*.msi' -exec cp {} release/ \;
+          find artifacts -name '*.dmg' -exec cp {} release/ \;
+          find artifacts -name '*.AppImage' -exec cp {} release/ \;
+          find artifacts -name '*.deb' -exec cp {} release/ \;
+          ls -la release/
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Open FEM2D Studio ${{ github.ref_name }}
+          prerelease: false
+          draft: true
+          generate_release_notes: true
+          body: |
+            **Downloads:**
+            - **Windows:** `.exe` (NSIS-installer) / `.msi`
+            - **macOS:** `.dmg` (universal)
+            - **Linux:** `.AppImage` / `.deb`
+          files: release/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,11 @@ jobs:
         run: npm ci
         working-directory: design-mockup
 
+      # tauri-action draait `npm run tauri build` in de projectroot; daarvoor
+      # moet @tauri-apps/cli uit de root-dependencies beschikbaar zijn.
+      - name: Install root dependencies
+        run: npm ci
+
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0
         env:

--- a/design-mockup/package-lock.json
+++ b/design-mockup/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "open-template",
+  "name": "open-fem2d-studio",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "open-template",
+      "name": "open-fem2d-studio",
       "version": "0.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",
+        "@tauri-apps/plugin-fs": "^2.5.1",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-os": "^2.3.2",
         "@tauri-apps/plugin-store": "^2.4.2",
@@ -65,7 +66,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1183,9 +1183,9 @@
       ]
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
+      "integrity": "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1418,6 +1418,15 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@tauri-apps/plugin-fs": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.5.1.tgz",
+      "integrity": "sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
+      }
+    },
     "node_modules/@tauri-apps/plugin-opener": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.3.tgz",
@@ -1467,7 +1476,6 @@
       "resolved": "https://registry.npmjs.org/@thatopen/fragments/-/fragments-3.3.6.tgz",
       "integrity": "sha512-obzaDjcjsyjUU4/B9q/5DSIRUbhQ+za4JC/wDPgoSgDKofVCJ9YrpuBNZ+0QHGbUcF03+Uv2kzG9hsCOsUgX6Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "earcut": "^3.0.1",
         "flatbuffers": "25.2.10",
@@ -1553,7 +1561,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1668,7 +1675,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1945,7 +1951,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6"
       },
@@ -2114,7 +2119,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2162,7 +2166,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2348,8 +2351,7 @@
       "version": "0.183.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
       "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.7.0",
@@ -2383,7 +2385,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2453,7 +2454,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/design-mockup/package.json
+++ b/design-mockup/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2",
+    "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-os": "^2.3.2",
     "@tauri-apps/plugin-store": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build"
   },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,16 +30,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["msi", "nsis"],
-    "windows": {
-      "webviewInstallMode": {
-        "type": "embedBootstrapper",
-        "silent": true
-      }
-    },
-    "resources": [
-      "WebView2Loader.dll"
-    ],
+    "targets": ["msi", "nsis", "deb", "appimage", "app", "dmg"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "windows": {
+      "webviewInstallMode": {
+        "type": "embedBootstrapper",
+        "silent": true
+      }
+    },
+    "resources": [
+      "WebView2Loader.dll"
+    ]
+  }
+}


### PR DESCRIPTION
## Aanleiding

De repo heeft geen build- of release-workflow (`.github/workflows` bevat alleen `auto-assign-issues.yml`). Installers worden kennelijk handmatig gemaakt, en de releases bevatten daardoor alleen `Open.FEM2D.Studio_x.y.z_x64-setup.exe` en `_x64_en-US.msi`.

Gevolg: de OpenAEC Installer kan Open FEM2D Studio op Linux niet installeren. Die zoekt een `.AppImage` in de release-assets en vindt die niet. `bundle.targets` in `src-tauri/tauri.conf.json` stond bovendien op `["msi", "nsis"]`, dus alleen Windows.

## Wat deze PR doet

1. **`.github/workflows/release.yml`** — nieuw. Draait op een tag `v*` (en handmatig via `workflow_dispatch`):
   - `check`: bouwt eerst alleen de frontend, zodat een kapotte build niet drie platformen aan CI-tijd kost.
   - `build`: matrix over `windows-latest` (msi, nsis), `macos-latest` (app, dmg, universal) en `ubuntu-22.04` (appimage, deb).
   - `publish`: verzamelt de artefacten en maakt een **concept**-release, zodat de release-notities eerst nagelopen kunnen worden.

   Opzet, action-versies en Linux-apt-lijst zijn overgenomen van `OpenAEC-Foundation/open-speech-studio` (`.github/workflows/release.yml`), omdat die aantoonbaar werkt.

2. **`src-tauri/tauri.conf.json`** — `bundle.targets` uitgebreid naar `["msi", "nsis", "deb", "appimage", "app", "dmg"]`.

3. **`src-tauri/tauri.windows.conf.json`** — nieuw. `WebView2Loader.dll` en `webviewInstallMode` stonden in de gedeelde config en werden dus ook meegebundeld in een Linux- of macOS-bundel. Ze staan nu in de Windows-specifieke config, die Tauri v2 automatisch mee-merget op Windows. De Windows-bundel verandert hierdoor niet.

4. **`design-mockup/package.json`** — `@tauri-apps/plugin-fs` toegevoegd. Dit is nodig, geen opschoning: `src/App.tsx` en `src/io/projectFile.ts` importeren het pakket, maar het stond niet in de dependencies. Een schone `npm ci && npm run build` faalde daardoor met vier keer `TS2307: Cannot find module '@tauri-apps/plugin-fs'`. Lokaal werkte de build alleen door een `node_modules` die niet in de repo staat. Zonder deze regel faalt elke CI-build meteen.

## Wat wel is getest

Lokaal op Ubuntu, tegen deze branch:

- `cd design-mockup && npm ci && npm run build` — faalt op `master`, slaagt met deze wijziging.
- `tauri build --bundles appimage,deb` — volledig doorlopen, exit 0. Resultaat:
  - `Open FEM2D Studio_2.0.1_amd64.AppImage` (80.493.048 bytes)
  - `Open FEM2D Studio_2.0.1_amd64.deb` (4.768.054 bytes)

Daarmee is bewezen dat de Rust-code en de bundel-config op Linux werken; dat was de belangrijkste onzekerheid.

- `release.yml` is als YAML geparseerd (jobs, matrix en triggers laden correct).

## Wat NIET is getest

Wees hier alsjeblieft kritisch op bij de review:

- **De workflow zelf is nooit op GitHub Actions gedraaid.** Ik kan geen tag pushen naar deze repo. Padnamen, cache-keys en het `publish`-job-verzamelstap zijn ongetest.
- **De macOS-build is niet geverifieerd.** Geen Mac beschikbaar. `--target universal-apple-darwin` en `app,dmg` zijn overgenomen van de zusterrepo's, niet zelf uitgeprobeerd. Dit is de meest waarschijnlijke plek voor een eerste rode build.
- **De Windows-build is niet opnieuw geverifieerd.** De targets zijn ongewijzigd en de WebView2-instellingen zijn alleen verplaatst, maar ik heb geen Windows-build gedraaid om te bevestigen dat de merge van `tauri.windows.conf.json` uitpakt zoals bedoeld.
- **Code-signing ontbreekt.** `open-speech-studio` en `open-pdf-studio` ondertekenen hun Windows-binaries via `azure/trusted-signing-action`. Die stappen heb ik bewust weggelaten omdat ik niet kan zien of deze repo over de `AZURE_*` secrets beschikt. Zijn die er, dan is dat een logische vervolgstap.
- **De AppImage is niet gestart.** Alleen gebouwd, niet uitgevoerd; deze omgeving heeft geen display.

## Twee punten die opvallen, buiten de scope van deze PR

- **`backend/`** bevat een Python/uvicorn-solver. Ik heb die *niet* meegebouwd en dat is bewust: `design-mockup/src/core/solver/SolverService.ts` probeert `POST /api/solve` en valt bij een fout terug op de lokale TypeScript-solver. `backend/run.sh` noemt zichzelf een dev-startscript en er is geen sidecar-configuratie (`bundle.externalBin`) in `tauri.conf.json`. De gebundelde app draait dus op de fallback — net als de huidige Windows-releases. Als de bedoeling is dat de Python-solver mee gaat, dan is dat een aparte wijziging (sidecar of gebundelde interpreter) en hoor ik dat graag.
- **`node_modules/` in de root staat in git** (6.263 bestanden), terwijl `.gitignore` de map negeert. Het is bovendien een onvolledige boom van 39 pakketten. De workflow gebruikt hem niet — die installeert in `design-mockup/` — maar het is waarschijnlijk een ongeluk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
